### PR TITLE
[add] fake_cog_publisher

### DIFF
--- a/robot_kinetics/CMakeLists.txt
+++ b/robot_kinetics/CMakeLists.txt
@@ -147,8 +147,14 @@ include_directories(
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
 # add_executable(${PROJECT_NAME}_node src/robot_kinetics_node.cpp)
-set(COG_PUBLISHER_SRC src/cog_publisher_node.cpp src/cog_publisher.cpp src/robot_link.cpp)
-add_executable(cog_publisher_node ${COG_PUBLISHER_SRC})
+# set(COG_PUBLISHER_SRC src/cog_publisher_node.cpp src/cog_publisher.cpp src/robot_link.cpp)
+# add_executable(cog_publisher_node ${COG_PUBLISHER_SRC})
+
+set(FAKE_COG_PUBLISHER_SRC
+  src/fake_cog_publisher_node.cpp
+  src/fake_cog_publisher.cpp
+  )
+add_executable(fake_cog_publisher_node ${FAKE_COG_PUBLISHER_SRC})
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -161,7 +167,10 @@ add_executable(cog_publisher_node ${COG_PUBLISHER_SRC})
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(cog_publisher_node ${catkin_LIBRARIES} ${BOOST_LIBRARIES})# ${GAZEBO_LIBRARIES})
+# target_link_libraries(cog_publisher_node ${catkin_LIBRARIES} ${BOOST_LIBRARIES})# ${GAZEBO_LIBRARIES})
+
+target_link_libraries(fake_cog_publisher_node ${catkin_LIBRARIES} ${BOOST_LIBRARIES})# ${GAZEBO_LIBRARIES})
+
 
 #############
 ## Install ##

--- a/robot_kinetics/config/wam_v_config.yaml
+++ b/robot_kinetics/config/wam_v_config.yaml
@@ -1,0 +1,5 @@
+publish_frame: "base_link"
+publish_rate: 50
+cog_x: -1.0
+cog_y: 0.0
+cog_z: 1.0

--- a/robot_kinetics/include/fake_cog_publisher.h
+++ b/robot_kinetics/include/fake_cog_publisher.h
@@ -1,0 +1,35 @@
+#ifndef FAKE_COG_PUBLISHER_H_INCLUDED
+#define FAKE_COG_PUBLISHER_H_INCLUDED
+
+//headers for standard library
+#include <vector>
+
+//headers for ROS
+#include <ros/ros.h>
+
+// publish message
+#include <geometry_msgs/PointStamped.h>
+
+class fake_cog_publisher
+{
+public:
+  fake_cog_publisher();
+  
+  //publish CoG
+  void publish();
+  //parameter getter
+  inline int get_publish_rate(void) const {return this->publish_rate;};
+  inline double get_robot_total_mass(void) const {return this->robot_total_mass;};
+ 
+private:
+  ros::NodeHandle nh;
+  //ros publisher and subscriber
+  ros::Publisher fake_cog_point_pub;
+
+  //parameters
+  int publish_rate;
+  double robot_total_mass;
+  // following message is specialized for fake_cog_publisher
+  geometry_msgs::PointStamped fake_cog_point;
+};
+#endif

--- a/robot_kinetics/launch/fake_cog_publisher.launch
+++ b/robot_kinetics/launch/fake_cog_publisher.launch
@@ -1,0 +1,7 @@
+<launch>
+  
+  <node name="fake_cog_publisher" pkg="robot_kinetics" type="fake_cog_publisher_node" output="screen">
+    <rosparam file="$(find robot_kinetics)/config/wam_v_config.yaml" command="load"/>
+  </node>
+
+</launch>

--- a/robot_kinetics/src/fake_cog_publisher.cpp
+++ b/robot_kinetics/src/fake_cog_publisher.cpp
@@ -1,0 +1,45 @@
+//headers in this package
+#include <fake_cog_publisher.h>
+
+//headers for standard library
+#include<iostream>
+
+//headers for ROS
+#include <ros/ros.h>
+#include <ros/package.h>
+
+fake_cog_publisher::fake_cog_publisher()
+{
+  std::string robot_description_text;
+  //get publish_freme parameter
+  nh.param<std::string>(ros::this_node::getName()+"/publish_frame", fake_cog_point.header.frame_id, "base_link");
+  //get publish_rate parameter
+  nh.param<int>(ros::this_node::getName()+"/publish_rate", publish_rate, 50);
+
+  /////////////////////////////////////////////////
+  // get CoG information                        //
+  // This part exists only in fake_cog_publisher //
+  /////////////////////////////////////////////////
+  nh.param<double>(ros::this_node::getName()+"/cog_x",
+                   fake_cog_point.point.x, 0);
+  nh.param<double>(ros::this_node::getName()+"/cog_y",
+                   fake_cog_point.point.y, 0);
+  nh.param<double>(ros::this_node::getName()+"/cog_z",
+                   fake_cog_point.point.z, 0);
+  /////////////////////////////////////////////////
+
+  // advertise
+  fake_cog_point_pub = nh.advertise<geometry_msgs::PointStamped>("/cog/robot", 1);
+}
+ 
+
+void fake_cog_publisher::publish()
+{
+  // get current time
+  ros::Time now = ros::Time::now();
+
+  //input robot cog data
+  fake_cog_point.header.stamp = now;
+  //publish cog point of robot (whole body)
+  fake_cog_point_pub.publish(fake_cog_point);
+}

--- a/robot_kinetics/src/fake_cog_publisher_node.cpp
+++ b/robot_kinetics/src/fake_cog_publisher_node.cpp
@@ -1,0 +1,18 @@
+//headers in this package
+#include <fake_cog_publisher.h>
+
+//headers for ROS
+#include <ros/ros.h>
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "fake_cog_publisher");
+  fake_cog_publisher fake_cog_pub;
+  ros::Rate rate(fake_cog_pub.get_publish_rate());
+  while(ros::ok())
+  {
+    fake_cog_pub.publish();
+    rate.sleep();
+  }
+  return 0;
+}


### PR DESCRIPTION
# About
I added `fake_cog_publisher`.
This publisher will publish Center of Gravity(CoG) point information that is manualy set into `/cog/robot` topic as `geometry_msgs/PointStamped` message.

The base frame and the CoG point is set by yaml file.
In the yaml file, we can set following parameters.

- publish_frame: base frame name
- publish_rate: publish rate
- cog_x:  x  of CoG point
- cog_y:  y of CoG point
- cog_z: z of CoG point

# To check the execution
```bash
$ roslaunch robot_kinetics fake_cog_publisher.launch
```